### PR TITLE
🧹 Refactor default_config function in src/config/mod.rs

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -305,24 +305,14 @@ impl Config {
 
     pub fn default_config() -> Self {
         Self {
-            provider: ProviderConfig {
-                name: "anthropic".to_string(),
-                api_key: None,
-                base_url: None,
-            },
+            provider: ProviderConfig::default(),
             embeddings: EmbeddingsConfig::default(),
             agent: AgentConfig::default(),
             model: "claude-sonnet-4-6".to_string(),
             system_prompt: "You are a helpful AI assistant.".to_string(),
             workspace: PathBuf::from("."),
             storage: StorageConfig::default(),
-            runtime: RuntimeConfig {
-                kind: "native".to_string(),
-                docker_image: None,
-                memory_limit_mb: None,
-                state_path: None,
-                self_update: SelfUpdateConfig::default(),
-            },
+            runtime: RuntimeConfig::default(),
             hosting: HostingConfig::default(),
             observability: ObservabilityConfig::default(),
             channel: ChannelConfig::default(),


### PR DESCRIPTION
🎯 **What:** Simplified the `default_config` function in `src/config/mod.rs` by replacing explicitly nested struct initializations with their respective `Default::default()` calls for `provider` and `runtime`.
💡 **Why:** This reduces duplicate code and ensures that any future changes to the default values of `ProviderConfig` or `RuntimeConfig` are correctly propagated without needing to touch this configuration file load sequence. It makes the function cleaner and shorter.
✅ **Verification:** Verified that `impl Default for ProviderConfig` and `impl Default for RuntimeConfig` exactly match the nested definitions that were replaced (e.g. `ProviderConfig::default()` returns `name: "anthropic".to_string()`, and `RuntimeConfig::default()` returns `kind: "native".to_string()`), ensuring complete preservation of behavior. Ran format checks successfully.
✨ **Result:** Improved readability and simplified `default_config()` by leveraging idiomatic Rust defaults.

---
*PR created automatically by Jules for task [5731761544231071887](https://jules.google.com/task/5731761544231071887) started by @undivisible*