### PR TITLE
🧹 Refactor medium length function 'refresh' in oauth provider

### DIFF
--- a/src/providers/oauth.rs
+++ b/src/providers/oauth.rs
@@ -1,9 +1,17 @@
 //! OAuth token support for Anthropic
 //! Converts Claude.dev OAuth tokens (oat01) to API calls via token exchange
 
+use serde::Deserialize;
 use serde_json::Value;
 use std::sync::Arc;
 use tokio::sync::RwLock;
+
+#[derive(Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    refresh_token: Option<String>,
+    expires_in: Option<i64>,
+}
 
 /// OAuth token cache (refreshed as needed)
 #[derive(Clone)]
@@ -42,15 +50,8 @@ impl OAuthTokenCache {
             .ok_or_else(|| anyhow::anyhow!("Failed to get valid token"))
     }
 
-    /// Refresh token from Anthropic OAuth endpoint
-    async fn refresh(&self) -> anyhow::Result<()> {
-        let refresh_token = {
-            let rt = self.refresh_token.read().await;
-            rt.clone()
-                .ok_or_else(|| anyhow::anyhow!("No refresh token available"))?
-        };
-
-        // Exchange refresh token for new access token
+    /// Exchange refresh token for new access token
+    async fn exchange_refresh_token(refresh_token: &str) -> anyhow::Result<TokenResponse> {
         let client = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(30))
             .build()?;
@@ -59,7 +60,7 @@ impl OAuthTokenCache {
             .post("https://api.anthropic.com/v1/oauth/token")
             .json(&serde_json::json!({
                 "grant_type": "refresh_token",
-                "refresh_token": &refresh_token,
+                "refresh_token": refresh_token,
             }))
             .send()
             .await?;
@@ -71,18 +72,26 @@ impl OAuthTokenCache {
             ));
         }
 
-        let body = response.json::<Value>().await?;
-        let new_token = body["access_token"]
-            .as_str()
-            .ok_or_else(|| anyhow::anyhow!("No access_token in refresh response"))?;
-        let new_refresh = body["refresh_token"].as_str();
-        let expires_in = body["expires_in"].as_i64().unwrap_or(3600) * 1000; // Convert to ms
+        let body = response.json::<TokenResponse>().await?;
+        Ok(body)
+    }
 
+    /// Refresh token from Anthropic OAuth endpoint
+    async fn refresh(&self) -> anyhow::Result<()> {
+        let refresh_token = {
+            let rt = self.refresh_token.read().await;
+            rt.clone()
+                .ok_or_else(|| anyhow::anyhow!("No refresh token available"))?
+        };
+
+        let body = Self::exchange_refresh_token(&refresh_token).await?;
+
+        let expires_in = body.expires_in.unwrap_or(3600) * 1000; // Convert to ms
         let new_expires = chrono::Utc::now().timestamp_millis() + expires_in;
 
-        *self.token.write().await = Some(new_token.to_string());
-        if let Some(r) = new_refresh {
-            *self.refresh_token.write().await = Some(r.to_string());
+        *self.token.write().await = Some(body.access_token);
+        if let Some(r) = body.refresh_token {
+            *self.refresh_token.write().await = Some(r);
         }
         *self.expires_at.write().await = new_expires;
 


### PR DESCRIPTION
🎯 **What:** Extracted the API request and parsing logic from the `refresh` function into a separate `exchange_refresh_token` associated function in `src/providers/oauth.rs`. I also added a `TokenResponse` struct with Serde `Deserialize` to parse the API response strongly.
💡 **Why:** The original `refresh` function was a bit long and mixed multiple concerns (preparing variables, making a network request, parsing unstructured JSON into types, and locking/updating state caches). This improves code modularity, strongly types the response instead of parsing untyped `serde_json::Value` items manually, and drastically reduces the length of the `refresh` body.
✅ **Verification:** Verified with code review tool and visual inspection via git diff that no cache logic or variable extraction behaviors were unintentionally changed. Evaluated edge case paths for optional fields (`expires_in`, `refresh_token`), mapped them appropriately into the `Deserialize` structure, and preserved the `timeout` values.
✨ **Result:** Improved maintainability and readability by using a strong typed struct to parse network responses and extracted a clean associated method to keep `refresh` focused on cache management.

---
*PR created automatically by Jules for task [9228280488009173221](https://jules.google.com/task/9228280488009173221) started by @undivisible*