### PR TITLE
🧹 [code health] Refactor `build_system_prompt` file fetching

### DIFF
--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -19,19 +19,10 @@ pub async fn build_system_prompt(workspace: &Path) -> String {
         ("MEMORY.md", "## Long-Term Memory", 8_000),
     ];
 
-    let mut readers = Vec::with_capacity(files.len());
-    for (filename, header, limit) in files {
-        readers.push(async move {
-            read_file(workspace, filename, limit)
-                .await
-                .map(|content| format!("{header}\n{content}"))
-        });
-    }
-
     let mut parts = Vec::new();
-    for reader in readers {
-        if let Some(content) = reader.await {
-            parts.push(content);
+    for (filename, header, limit) in files {
+        if let Some(content) = read_file(workspace, filename, limit).await {
+            parts.push(format!("{header}\n{content}"));
         }
     }
 


### PR DESCRIPTION
🎯 **What:** Simplified the logic in `build_system_prompt` inside `src/prompt.rs`.
💡 **Why:** The previous code iterated over the configuration array to allocate a `Vec` of async tasks, and then iterated *again* to actually await them one by one. Since Rust futures are lazy and the old code didn't use `tokio::spawn`, the old logic was strictly sequential anyway. The new implementation simplifies this by doing the `.await` inline within a single iteration block. This improves code readability and slightly reduces allocation overhead.
✅ **Verification:** Verified by running `cargo test --lib prompt` which executed the prompt module tests, as well as checking against `cargo fmt` guidelines. No functionality change is introduced; only the intermediate allocation has been removed.
✨ **Result:** Clean, simple execution logic using standard Rust `.await` paradigms.

---
*PR created automatically by Jules for task [6140392357612159390](https://jules.google.com/task/6140392357612159390) started by @undivisible*