### PR TITLE
🧪 Add edge case tests for cosine similarity

### DIFF
--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -93,10 +93,28 @@ mod tests {
     fn test_cosine_similarity() {
         let a = vec![1.0, 0.0, 0.0];
         let b = vec![1.0, 0.0, 0.0];
-        assert_eq!(cosine_similarity(&a, &b), 1.0);
+        assert!((cosine_similarity(&a, &b) - 1.0).abs() < 1e-6);
 
         let a = vec![1.0, 0.0];
         let b = vec![0.0, 1.0];
-        assert_eq!(cosine_similarity(&a, &b), 0.0);
+        assert!((cosine_similarity(&a, &b) - 0.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_cosine_similarity_edge_cases() {
+        // Empty vectors
+        let a: Vec<f32> = vec![];
+        let b: Vec<f32> = vec![];
+        assert!((cosine_similarity(&a, &b) - 0.0).abs() < 1e-6);
+
+        // Mismatched lengths
+        let a = vec![1.0];
+        let b = vec![1.0, 0.0];
+        assert!((cosine_similarity(&a, &b) - 0.0).abs() < 1e-6);
+
+        // Zero vectors
+        let a = vec![0.0, 0.0];
+        let b = vec![0.0, 0.0];
+        assert!((cosine_similarity(&a, &b) - 0.0).abs() < 1e-6);
     }
 }


### PR DESCRIPTION
🎯 **What:** The `cosine_similarity` function lacked tests for important edge cases: empty arrays, mismatched input arrays, and zero-magnitude arrays. This gap in testing is addressed.
📊 **Coverage:** The following scenarios are now tested:
- Empty vectors (`[]` vs `[]`)
- Mismatched lengths (`[1.0]` vs `[1.0, 0.0]`)
- Zero vectors (`[0.0, 0.0]` vs `[0.0, 0.0]`)
Additionally, standard tests were updated to use `abs() < 1e-6` floating point comparison.
✨ **Result:** Test coverage for `src/embeddings.rs` is improved and ensures future refactoring does not break these edge cases.

---
*PR created automatically by Jules for task [16120780119959259262](https://jules.google.com/task/16120780119959259262) started by @undivisible*