### PR TITLE
🧹 Refactor default_config to use Default implementations

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -305,24 +305,14 @@ impl Config {
 
     pub fn default_config() -> Self {
         Self {
-            provider: ProviderConfig {
-                name: "anthropic".to_string(),
-                api_key: None,
-                base_url: None,
-            },
+            provider: ProviderConfig::default(),
             embeddings: EmbeddingsConfig::default(),
             agent: AgentConfig::default(),
             model: "claude-sonnet-4-6".to_string(),
             system_prompt: "You are a helpful AI assistant.".to_string(),
             workspace: PathBuf::from("."),
             storage: StorageConfig::default(),
-            runtime: RuntimeConfig {
-                kind: "native".to_string(),
-                docker_image: None,
-                memory_limit_mb: None,
-                state_path: None,
-                self_update: SelfUpdateConfig::default(),
-            },
+            runtime: RuntimeConfig::default(),
             hosting: HostingConfig::default(),
             observability: ObservabilityConfig::default(),
             channel: ChannelConfig::default(),


### PR DESCRIPTION
🎯 **What:** Simplified the `default_config` method in `src/config/mod.rs` by utilizing the existing `Default` implementations for `ProviderConfig` and `RuntimeConfig` instead of constructing the identical defaults manually inline.

💡 **Why:** This improves maintainability by removing code duplication. If the default configuration for `ProviderConfig` or `RuntimeConfig` changes in the future, it only needs to be updated in one place (the `impl Default` block). It also reduces the line count of the `default_config` method, making it more readable.

✅ **Verification:** Verified by checking that `impl Default for ProviderConfig` and `impl Default for RuntimeConfig` exist in the file and match the manually constructed structs. Also ran `cargo fmt --all -- --check` successfully. (Full cargo builds timed out, but the change is a trivial use of existing methods).

✨ **Result:** The `default_config` function is cleaner, less repetitive, and delegates to the respective default initializers.

---
*PR created automatically by Jules for task [14123163113539861646](https://jules.google.com/task/14123163113539861646) started by @undivisible*