### PR TITLE
🧹 [Code Health] Refactor SelfUpdater start method

### DIFF
--- a/src/self_update.rs
+++ b/src/self_update.rs
@@ -25,38 +25,40 @@ impl SelfUpdater {
     }
 
     pub fn start(self) -> tokio::task::JoinHandle<()> {
-        tokio::spawn(async move {
-            if !self.config.enabled {
-                tracing::info!("self-update disabled");
-                return;
-            }
+        tokio::spawn(self.run_loop())
+    }
 
-            let mut interval =
-                tokio::time::interval(tokio::time::Duration::from_secs(self.config.interval_secs));
+    async fn run_loop(self) {
+        if !self.config.enabled {
+            tracing::info!("self-update disabled");
+            return;
+        }
+
+        let mut interval =
+            tokio::time::interval(tokio::time::Duration::from_secs(self.config.interval_secs));
+        interval.tick().await;
+
+        loop {
             interval.tick().await;
-
-            loop {
-                interval.tick().await;
-                match self.run_once().await {
-                    Ok(UpdateOutcome::Updated { restarted }) => {
-                        tracing::info!(restarted, "self-update applied");
-                    }
-                    Ok(UpdateOutcome::AlreadyCurrent) => {
-                        tracing::debug!("self-update: already current");
-                    }
-                    Ok(UpdateOutcome::DirtyWorktree) => {
-                        tracing::warn!("self-update: skipping dirty worktree");
-                    }
-                    Ok(UpdateOutcome::NoRepo) => {
-                        tracing::debug!("self-update: workspace is not a git repo");
-                    }
-                    Ok(UpdateOutcome::Disabled) => break,
-                    Err(error) => {
-                        tracing::warn!(error = %error, "self-update failed");
-                    }
+            match self.run_once().await {
+                Ok(UpdateOutcome::Updated { restarted }) => {
+                    tracing::info!(restarted, "self-update applied");
+                }
+                Ok(UpdateOutcome::AlreadyCurrent) => {
+                    tracing::debug!("self-update: already current");
+                }
+                Ok(UpdateOutcome::DirtyWorktree) => {
+                    tracing::warn!("self-update: skipping dirty worktree");
+                }
+                Ok(UpdateOutcome::NoRepo) => {
+                    tracing::debug!("self-update: workspace is not a git repo");
+                }
+                Ok(UpdateOutcome::Disabled) => break,
+                Err(error) => {
+                    tracing::warn!(error = %error, "self-update failed");
                 }
             }
-        })
+        }
     }
 
     pub async fn run_once(&self) -> anyhow::Result<UpdateOutcome> {


### PR DESCRIPTION
🎯 **What:** Extracted the core loop of `SelfUpdater::start` into a new async `run_loop` method.
💡 **Why:** The original `start` method contained a deeply nested async block which obscured the high-level intent of the method (spawning a background task) and made it overly long. Separating the loop out improves readability and structural clarity.
✅ **Verification:** Verified functionally by manually reviewing the isolated abstraction to ensure no behavioral changes occurred. 
✨ **Result:** A much cleaner `start` function and logical separation of the looping logic into `run_loop`.

---
*PR created automatically by Jules for task [10275345499857828688](https://jules.google.com/task/10275345499857828688) started by @undivisible*