### PR TITLE
🧹 Refactor `spawn_local_message_bridge` to improve code health

### DIFF
--- a/src/telegram_runtime.rs
+++ b/src/telegram_runtime.rs
@@ -108,38 +108,47 @@ pub async fn run_telegram_chat(run: TelegramChatRun<'_>) -> anyhow::Result<()> {
     Ok(())
 }
 
+#[derive(Clone)]
+struct LocalBridgeState {
+    tx: tokio::sync::mpsc::Sender<IncomingMessage>,
+    chat_id: String,
+}
+
+async fn handle_local_message(
+    State(state): State<LocalBridgeState>,
+    Json(body): Json<serde_json::Value>,
+) -> (axum::http::StatusCode, &'static str) {
+    let text = body["message"].as_str().unwrap_or("").to_string();
+    if text.is_empty() {
+        return (
+            axum::http::StatusCode::BAD_REQUEST,
+            "missing 'message' field",
+        );
+    }
+    let msg = IncomingMessage {
+        id: format!("cli-{}", chrono::Utc::now().timestamp()),
+        chat_id: state.chat_id.clone(),
+        sender_id: "cli".to_string(),
+        sender_name: Some("CLI".to_string()),
+        text,
+        timestamp: chrono::Utc::now(),
+        is_group: false,
+        reply_to: None,
+    };
+    let _ = state.tx.send(msg).await;
+    (axum::http::StatusCode::OK, "queued")
+}
+
 fn spawn_local_message_bridge(cli_tx: tokio::sync::mpsc::Sender<IncomingMessage>, chat_id: i64) {
     let chat_id_clone = chat_id.to_string();
+    let state = LocalBridgeState {
+        tx: cli_tx,
+        chat_id: chat_id_clone,
+    };
     tokio::spawn(async move {
         let app = Router::new()
-            .route(
-                "/message",
-                post(
-                    |State(tx): State<tokio::sync::mpsc::Sender<IncomingMessage>>,
-                     Json(body): Json<serde_json::Value>| async move {
-                        let text = body["message"].as_str().unwrap_or("").to_string();
-                        if text.is_empty() {
-                            return (
-                                axum::http::StatusCode::BAD_REQUEST,
-                                "missing 'message' field",
-                            );
-                        }
-                        let msg = IncomingMessage {
-                            id: format!("cli-{}", chrono::Utc::now().timestamp()),
-                            chat_id: chat_id_clone.clone(),
-                            sender_id: "cli".to_string(),
-                            sender_name: Some("CLI".to_string()),
-                            text,
-                            timestamp: chrono::Utc::now(),
-                            is_group: false,
-                            reply_to: None,
-                        };
-                        let _ = tx.send(msg).await;
-                        (axum::http::StatusCode::OK, "queued")
-                    },
-                ),
-            )
-            .with_state(cli_tx);
+            .route("/message", post(handle_local_message))
+            .with_state(state);
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:31337")
             .await


### PR DESCRIPTION
🎯 **What:** Extracted the inline routing closure within `spawn_local_message_bridge` into a standalone async function `handle_local_message`. Introduced a `LocalBridgeState` struct to pass state cleanly.
💡 **Why:** The inline closure made the router configuration bloated, and capturing state inside the closure limited readability and reuse. Passing state using Axum's idiomatic `.with_state()` extractor resolves this and flattens the code structure.
✅ **Verification:** Verified the code changes via `cargo check`/`cargo fmt`.
✨ **Result:** A more readable and maintainable codebase, following Axum's idiomatic state and routing patterns.

---
*PR created automatically by Jules for task [3667825568266630524](https://jules.google.com/task/3667825568266630524) started by @undivisible*