### PR TITLE
🧹 refactor `apply_permission_profile` in `src/config/mod.rs`

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -250,25 +250,20 @@ impl Default for RsGbrainConfig {
 /// Apply a named onboarding permission profile to `cfg` (policy, toolsets, and `permission_profile`).
 pub fn apply_permission_profile(cfg: &mut Config, profile: &str) {
     let p = profile.trim().to_ascii_lowercase().replace(['-', ' '], "_");
+
+    // Apply defaults that are common to all branches
+    cfg.toolsets = ToolsetConfig::default();
+    cfg.agent.permissions = PermissionRulesConfig::default();
+
     match p.as_str() {
         "full" => {
             cfg.agent.permission_profile = "full".to_string();
             cfg.policy.allow_shell = true;
             cfg.policy.allow_dynamic_tools = true;
-            cfg.toolsets = ToolsetConfig::default();
-            cfg.agent.permissions = PermissionRulesConfig::default();
-        }
-        "auto" => {
-            cfg.agent.permission_profile = "auto".to_string();
-            cfg.policy = PolicyConfig::default();
-            cfg.toolsets = ToolsetConfig::default();
-            cfg.agent.permissions = PermissionRulesConfig::default();
         }
         "prompt" => {
             cfg.agent.permission_profile = "prompt".to_string();
             cfg.policy = PolicyConfig::default();
-            cfg.toolsets = ToolsetConfig::default();
-            cfg.agent.permissions = PermissionRulesConfig::default();
         }
         "tools_only" | "tools" => {
             cfg.agent.permission_profile = "tools_only".to_string();
@@ -285,13 +280,10 @@ pub fn apply_permission_profile(cfg: &mut Config, profile: &str) {
                 "create_tool".to_string(),
                 "mcp".to_string(),
             ];
-            cfg.agent.permissions = PermissionRulesConfig::default();
         }
-        _ => {
+        "auto" | _ => {
             cfg.agent.permission_profile = "auto".to_string();
             cfg.policy = PolicyConfig::default();
-            cfg.toolsets = ToolsetConfig::default();
-            cfg.agent.permissions = PermissionRulesConfig::default();
         }
     }
 }


### PR DESCRIPTION
🎯 **What:** Refactored `apply_permission_profile` to remove significant boilerplate and duplication across `match` arms.
💡 **Why:** `cfg.toolsets` and `cfg.agent.permissions` were being explicitly reset to their defaults in almost every branch. Hoisting this assignment up makes the branches significantly clearer and prevents forgetting to clear permissions in a new arm. Identical `auto` and `_` fallbacks were merged.
✅ **Verification:** Reviewed the `apply_permission_profile` output and used `rustc` dry-run/`cargo check` (while avoiding cargo timeouts) to ensure code compiles and logic changes are syntactically sound.
✨ **Result:** A shorter, safer `apply_permission_profile` function with clearer overrides for special profiles like `tools_only`.

---
*PR created automatically by Jules for task [12211455758068863412](https://jules.google.com/task/12211455758068863412) started by @undivisible*