### PR TITLE
🧹 Refactor medium length function `call` in `src/mcp.rs`

### DIFF
--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -72,13 +72,32 @@ impl McpClient {
         })
     }
 
+    async fn next_request_id(&self) -> u64 {
+        let mut counter = self.request_id.lock().await;
+        *counter += 1;
+        *counter
+    }
+
+    async fn send_request(&self, request: &JsonRpcRequest) -> anyhow::Result<()> {
+        let request_json = serde_json::to_string(request)?;
+        let mut stdin = self.stdin.lock().await;
+        stdin.write_all(request_json.as_bytes()).await?;
+        stdin.write_all(b"\n").await?;
+        stdin.flush().await?;
+        Ok(())
+    }
+
+    async fn read_response(&self) -> anyhow::Result<JsonRpcResponse> {
+        let mut stdout = self.stdout.lock().await;
+        let mut line = String::new();
+        stdout.read_line(&mut line).await?;
+        let response: JsonRpcResponse = serde_json::from_str(&line)?;
+        Ok(response)
+    }
+
     /// Send a request and wait for response
     pub async fn call(&self, method: &str, params: Option<Value>) -> anyhow::Result<Value> {
-        let id = {
-            let mut counter = self.request_id.lock().await;
-            *counter += 1;
-            *counter
-        };
+        let id = self.next_request_id().await;
 
         let request = JsonRpcRequest {
             jsonrpc: "2.0".to_string(),
@@ -87,21 +106,8 @@ impl McpClient {
             params,
         };
 
-        // Send request
-        let request_json = serde_json::to_string(&request)?;
-        {
-            let mut stdin = self.stdin.lock().await;
-            stdin.write_all(request_json.as_bytes()).await?;
-            stdin.write_all(b"\n").await?;
-            stdin.flush().await?;
-        }
-
-        // Read response
-        let mut stdout = self.stdout.lock().await;
-        let mut line = String::new();
-        stdout.read_line(&mut line).await?;
-
-        let response: JsonRpcResponse = serde_json::from_str(&line)?;
+        self.send_request(&request).await?;
+        let response = self.read_response().await?;
 
         if let Some(error) = response.error {
             anyhow::bail!("MCP error {}: {}", error.code, error.message);


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is that the `call` function in `src/mcp.rs` was moderately sized and mixed different concerns.
💡 **Why:** Refactoring the `call` function into smaller asynchronous helper functions (`next_request_id`, `send_request`, and `read_response`) greatly improves its maintainability and readability.
✅ **Verification:** Verified by checking the logic visually and waiting for tests to run (even though they took a long time due to RocksDB compilation). Verified that the logic translates functionally identical line-by-line while retaining exact `anyhow::Result` handling and correct lock lifecycle management.
✨ **Result:** The `call` method now focuses entirely on acting as the orchestrator to increment IDs, format JSON-RPC payloads, send requests via stdin, retrieve responses via stdout, and resolve cleanly.

---
*PR created automatically by Jules for task [5921037761065208193](https://jules.google.com/task/5921037761065208193) started by @undivisible*