### PR TITLE
🧪 test: add unit tests for agent_mode_from_permission_profile

### DIFF
--- a/src/agent/mode.rs
+++ b/src/agent/mode.rs
@@ -250,3 +250,57 @@ You are coordinating parallel coding agents. Follow these rules:
 - Validate and integrate each agent's output before merging
 - Reassign or handle failed tasks yourself
 - Report the outcome of each agent with status and a brief summary";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_agent_mode_from_permission_profile() {
+        // Test "full" mapping to BypassPermissions
+        assert!(matches!(
+            agent_mode_from_permission_profile("full"),
+            AgentMode::BypassPermissions
+        ));
+        // Test whitespace trimming and case insensitivity
+        assert!(matches!(
+            agent_mode_from_permission_profile("  FULL  "),
+            AgentMode::BypassPermissions
+        ));
+
+        // Test "prompt" mapping to Coding with plan_approval true
+        assert!(matches!(
+            agent_mode_from_permission_profile("prompt"),
+            AgentMode::Coding {
+                plan_approval: true,
+                project_path: None
+            }
+        ));
+        // Test whitespace trimming and case insensitivity
+        assert!(matches!(
+            agent_mode_from_permission_profile(" ProMpT\n"),
+            AgentMode::Coding {
+                plan_approval: true,
+                project_path: None
+            }
+        ));
+
+        // Test fallback to Auto for unknown values
+        assert!(matches!(
+            agent_mode_from_permission_profile(""),
+            AgentMode::Auto
+        ));
+        assert!(matches!(
+            agent_mode_from_permission_profile("auto"),
+            AgentMode::Auto
+        ));
+        assert!(matches!(
+            agent_mode_from_permission_profile("unknown-profile"),
+            AgentMode::Auto
+        ));
+        assert!(matches!(
+            agent_mode_from_permission_profile("some profile"),
+            AgentMode::Auto
+        ));
+    }
+}


### PR DESCRIPTION
🎯 **What:** Missing test coverage for the `agent_mode_from_permission_profile` configuration mapping logic.
📊 **Coverage:** Now tests the exact mappings for "full" and "prompt", whitespace trimming, case insensitivity, and fallback edge cases (empty strings, hyphens/spaces to "Auto").
✨ **Result:** Improved test coverage and reliability for agent runtime mode initialization, ensuring configuration states correctly map to the intended capabilities.

---
*PR created automatically by Jules for task [14681444507725629479](https://jules.google.com/task/14681444507725629479) started by @undivisible*