### PR TITLE
🧹 Refactor duplicated task dependency logic in TeamManager

### DIFF
--- a/src/swarm/team.rs
+++ b/src/swarm/team.rs
@@ -86,6 +86,20 @@ impl TeamManager {
 
     // === Task Board ===
 
+    async fn has_unresolved_dependencies(&self, blocked_by: &[String], ignore_task_id: Option<&str>) -> Result<bool> {
+        for blocker_id in blocked_by {
+            if Some(blocker_id.as_str()) == ignore_task_id {
+                continue;
+            }
+            if let Some(blocker) = self.storage.get_team_task(blocker_id).await? {
+                if blocker.status != "done" {
+                    return Ok(true);
+                }
+            }
+        }
+        Ok(false)
+    }
+
     /// Create a task on the team board
     pub async fn create_task(
         &self,
@@ -138,17 +152,7 @@ impl TeamManager {
 
         // Check if task is blocked
         if task.status == "blocked" {
-            // Check if blockers are resolved
-            let mut still_blocked = false;
-            for blocker_id in &task.blocked_by {
-                if let Some(blocker) = self.storage.get_team_task(blocker_id).await? {
-                    if blocker.status != "done" {
-                        still_blocked = true;
-                        break;
-                    }
-                }
-            }
-            if still_blocked {
+            if self.has_unresolved_dependencies(&task.blocked_by, None).await? {
                 bail!("Task '{}' is blocked by incomplete dependencies", task_id);
             }
         }
@@ -170,20 +174,7 @@ impl TeamManager {
         let blocked = self.storage.get_blocked_tasks(&task.team_id).await?;
         for bt in blocked {
             if bt.blocked_by.contains(&task_id.to_string()) {
-                // Check if all blockers are now done
-                let mut all_done = true;
-                for b in &bt.blocked_by {
-                    if b == task_id {
-                        continue; // This one is now done
-                    }
-                    if let Some(blocker) = self.storage.get_team_task(b).await? {
-                        if blocker.status != "done" {
-                            all_done = false;
-                            break;
-                        }
-                    }
-                }
-                if all_done {
+                if !self.has_unresolved_dependencies(&bt.blocked_by, Some(task_id)).await? {
                     // Unblock the task (move from blocked to pending)
                     self.storage.unblock_task(&bt.task_id).await?;
                 }


### PR DESCRIPTION
🎯 **What:** Extracted task dependency resolution logic from `claim_task` and `complete_task` into a new `has_unresolved_dependencies` private async helper method in `src/swarm/team.rs`.
💡 **Why:** To remove duplicated iteration loops, simplify control flow, and improve the overall readability and maintainability of `TeamManager`.
✅ **Verification:** Verified `git diff --staged` matches exactly the required refactoring, ran `cargo test --no-default-features --features="channel-telegram" swarm_integration` locally and saw that all swarm integration tests continue to pass.
✨ **Result:** A cleaner implementation in `claim_task` and `complete_task` without behavioral changes.

---
*PR created automatically by Jules for task [5802777784814528149](https://jules.google.com/task/5802777784814528149) started by @undivisible*