### PR TITLE
🧹 Refactor Ollama chat to use helper methods for improved readability

### DIFF
--- a/src/providers/ollama.rs
+++ b/src/providers/ollama.rs
@@ -17,6 +17,33 @@ impl OllamaProvider {
             base_url: base_url.into(),
         }
     }
+
+    fn build_request_body(&self, request: &ChatRequest<'_>) -> Value {
+        let messages: Vec<Value> = request
+            .messages
+            .iter()
+            .map(|m| serde_json::json!({ "role": &m.role, "content": &m.content }))
+            .collect();
+
+        serde_json::json!({
+            "model": request.model,
+            "messages": messages,
+            "stream": false,
+            "options": {
+                "temperature": request.temperature,
+            }
+        })
+    }
+
+    fn parse_response(&self, data: Value) -> ChatResponse {
+        let text = data["message"]["content"].as_str().map(String::from);
+
+        ChatResponse {
+            text,
+            tool_calls: vec![],
+            usage: None,
+        }
+    }
 }
 
 impl Default for OllamaProvider {
@@ -42,21 +69,7 @@ impl Provider for OllamaProvider {
 
     async fn chat(&self, request: &ChatRequest<'_>) -> anyhow::Result<ChatResponse> {
         let client = reqwest::Client::new();
-
-        let messages: Vec<Value> = request
-            .messages
-            .iter()
-            .map(|m| serde_json::json!({ "role": &m.role, "content": &m.content }))
-            .collect();
-
-        let body = serde_json::json!({
-            "model": request.model,
-            "messages": messages,
-            "stream": false,
-            "options": {
-                "temperature": request.temperature,
-            }
-        });
+        let body = self.build_request_body(request);
 
         let resp = send_with_retry(
             client
@@ -72,12 +85,6 @@ impl Provider for OllamaProvider {
         }
 
         let data: Value = resp.json().await?;
-        let text = data["message"]["content"].as_str().map(String::from);
-
-        Ok(ChatResponse {
-            text,
-            tool_calls: vec![],
-            usage: None,
-        })
+        Ok(self.parse_response(data))
     }
 }


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Refactored the medium-length `chat` function in `src/providers/ollama.rs` by extracting message payload construction and response mapping into separate, dedicated helper methods (`build_request_body` and `parse_response`).

💡 **Why:** How this improves maintainability
The original `chat` function was growing large by mixing request mapping, network interaction, and response parsing. Extracting these steps makes the `chat` method linear and easier to read. The helper functions are purely local formatting abstractions, improving unit-testability and maintainability.

✅ **Verification:** How you confirmed the change is safe
Ran `cargo check` and correctly configured local environment tests, verified type constraints, and obtained code review approval. The logic extracted is identical to the original logic, ensuring no regressions.

✨ **Result:** The improvement achieved
A cleaner `OllamaProvider` implementation where the `chat` function focuses solely on the asynchronous HTTP lifecycle.

---
*PR created automatically by Jules for task [3782159274106730897](https://jules.google.com/task/3782159274106730897) started by @undivisible*