### PR TITLE
MPL-2.0 + Hermes-like CLI QoL + cloud env

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,0 +1,15 @@
+FROM rust:bookworm
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
+        pkg-config \
+        libssl-dev \
+        clang \
+        git \
+        curl \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,9 @@
+{
+  "name": "apollo",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "install": "chmod +x scripts/cloud-agent-install.sh && ./scripts/cloud-agent-install.sh",
+  "agentCanUpdateSnapshot": true
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
-name = "apollo"
+name = "apollo-agent"
 version = "0.2.2"
 dependencies = [
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
-name = "apollo"
+name = "apollo-agent"
 version = "0.2.2"
 edition = "2021"
 description = "Local-first Rust AI agent runtime — Telegram-first, trait-driven, SurrealDB + RocksDB state layer."
 license = "MPL-2.0"
 readme = "README.md"
+documentation = "https://docs.rs/apollo-agent"
 repository = "https://github.com/tschk/apollo"
 homepage = "https://github.com/tschk/apollo"
 keywords = ["agent", "ai", "llm", "telegram", "automation"]
@@ -18,6 +19,10 @@ path = "src/main.rs"
 [[bin]]
 name = "apollo-install"
 path = "src/bin/apollo_install.rs"
+
+[lib]
+name = "apollo"
+path = "src/lib.rs"
 
 [features]
 default = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,13 @@ name = "apollo"
 version = "0.2.2"
 edition = "2021"
 description = "Local-first Rust AI agent runtime — Telegram-first, trait-driven, SurrealDB + RocksDB state layer."
-license = "MIT"
+license = "MPL-2.0"
+readme = "README.md"
 repository = "https://github.com/tschk/apollo"
+homepage = "https://github.com/tschk/apollo"
 keywords = ["agent", "ai", "llm", "telegram", "automation"]
 categories = ["command-line-utilities", "web-programming::http-client"]
+exclude = [".cursor/"]
 
 [[bin]]
 name = "apollo"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # apollo
 
+[![License: MPL-2.0](https://img.shields.io/badge/License-MPL_2.0-brightgreen.svg)](LICENSE)
+
 apollo is a **local-first Rust AI agent runtime** for people who want the bot on
 their own machine, not hidden behind a hosted control plane.
 
@@ -60,11 +62,21 @@ and feature-gated signed desktop actions through Praefectus
 ## Quick Start
 
 ```bash
-cargo build --release
+# From source
+cargo install --path .
+./scripts/install.sh   # build release + install to ~/.local/bin
 
-./target/release/apollo init
-./target/release/apollo chat --config apollo.json
-./target/release/apollo ask "summarize this repo" --config apollo.json
+apollo init          # interactive setup wizard (`apollo setup` is an alias)
+apollo               # start chatting (same as `apollo chat`)
+apollo ask "summarize this repo"
+apollo doctor        # diagnose config / deps
+```
+
+Install from a release binary (after build):
+
+```bash
+cargo build --release
+./target/release/apollo-install install
 ```
 
 ## Current Status
@@ -72,7 +84,7 @@ cargo build --release
 - ✅ `cargo clippy --all-targets` — 0 warnings
 - ✅ `cargo test` — 85 tests pass, 0 fail
 - ✅ `cargo build --release` — passes, ~14MB binary
-- ✅ v0.2.0 released
+- ✅ v0.2.0 — install from source or release binary; `cargo install apollo` pending crate rename (name reserved on crates.io)
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ and feature-gated signed desktop actions through Praefectus
 ## Quick Start
 
 ```bash
+# From crates.io (binaries: apollo, apollo-install)
+cargo install apollo-agent
+
 # From source
 cargo install --path .
 ./scripts/install.sh   # build release + install to ~/.local/bin
@@ -84,7 +87,7 @@ cargo build --release
 - ✅ `cargo clippy --all-targets` — 0 warnings
 - ✅ `cargo test` — 85 tests pass, 0 fail
 - ✅ `cargo build --release` — passes, ~14MB binary
-- ✅ v0.2.0 — install from source or release binary; `cargo install apollo` pending crate rename (name reserved on crates.io)
+- ✅ v0.2.0 — install from source, release binary, or `cargo install apollo-agent` (crates.io package; binaries `apollo`, `apollo-install`)
 
 ## Configuration
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -25,7 +25,7 @@ Last updated: 2026-06-16
 - Skill template preprocessing — `${HERMES_SKILL_DIR}` / `${HERMES_SESSION_ID}`
   variables + `!\`command\`` inline shell in SKILL.md
 - Cron scheduler — SurrealDB-backed with in-memory noop fallback for testing
-- Cargo publish v0.2.0 to crates.io
+- Cargo publish v0.2.0 to crates.io as `apollo-agent`
 
 ## Next
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -37,7 +37,7 @@ Last updated: 2026-06-16
 
 ## Next
 
-- [ ] Wire autonomous mode into CLI entrypoint (`apollo autonomous`)
+- [x] Wire autonomous mode into CLI entrypoint (`apollo autonomous`)
 - [ ] Add trajectory collection toggle in config.yaml
 - [ ] Add tests for Telegram markdown conversion and long-message chunking
 - [ ] Add tests for audio/sticker handling in Telegram

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -23,7 +23,7 @@ Last updated: 2026-06-16
 - [x] Hermes-style self-healing, loop detection, and compaction integration in
   loop_runner.rs
 - [x] All 85 tests pass, 0 clippy warnings
-- [x] v0.2.0 published to crates.io
+- [x] v0.2.0 published to crates.io as `apollo-agent`
 
 ### Previous (v0.1.x)
 - [x] SurrealDB memory schema includes `files`, `chunks`, FTS, and sticker cache

--- a/scripts/cloud-agent-install.sh
+++ b/scripts/cloud-agent-install.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v rustc >/dev/null 2>&1; then
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+fi
+
+# shellcheck disable=SC1091
+source "${HOME}/.cargo/env" 2>/dev/null || true
+
+rustup show active-toolchain >/dev/null 2>&1 || rustup default stable
+cargo fetch
+cargo check --all-targets

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_URL="${APOLLO_REPO:-https://github.com/tschk/apollo.git}"
+BRANCH="${APOLLO_BRANCH:-main}"
+INSTALL_DIR="${APOLLO_INSTALL_DIR:-$HOME/.local/bin}"
+
+CLONE_DIR=""
+
+cleanup() {
+  if [[ -n "$CLONE_DIR" && -d "$CLONE_DIR" ]]; then
+    rm -rf "$CLONE_DIR"
+  fi
+}
+
+find_repo_root() {
+  local dir="$1"
+  while [[ -n "$dir" && "$dir" != "/" ]]; do
+    if [[ -f "$dir/Cargo.toml" ]] && grep -q '^name = "apollo"' "$dir/Cargo.toml" 2>/dev/null; then
+      printf '%s\n' "$dir"
+      return 0
+    fi
+    dir="$(dirname "$dir")"
+  done
+  return 1
+}
+
+resolve_source() {
+  if [[ -n "${APOLLO_SOURCE_DIR:-}" ]]; then
+    printf '%s\n' "$APOLLO_SOURCE_DIR"
+    return 0
+  fi
+
+  local root=""
+  if root="$(find_repo_root "$(pwd)")"; then
+    printf '%s\n' "$root"
+    return 0
+  fi
+
+  if [[ -n "${BASH_SOURCE[0]:-}" ]]; then
+    local script="${BASH_SOURCE[0]}"
+    if [[ -f "$script" ]]; then
+      printf '%s\n' "$(cd "$(dirname "$script")/.." && pwd)"
+      return 0
+    fi
+  fi
+
+  if ! command -v git >/dev/null 2>&1; then
+    echo "error: git is required when not run from a source checkout" >&2
+    exit 1
+  fi
+
+  CLONE_DIR="$(mktemp -d)"
+  trap cleanup EXIT
+  git clone --depth 1 --branch "$BRANCH" "$REPO_URL" "$CLONE_DIR/apollo"
+  printf '%s\n' "$CLONE_DIR/apollo"
+}
+
+ensure_cargo() {
+  if command -v cargo >/dev/null 2>&1; then
+    return 0
+  fi
+  # shellcheck disable=SC1091
+  source "${HOME}/.cargo/env" 2>/dev/null || true
+  if command -v cargo >/dev/null 2>&1; then
+    return 0
+  fi
+  if ! command -v rustc >/dev/null 2>&1; then
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+    # shellcheck disable=SC1091
+    source "${HOME}/.cargo/env"
+  fi
+}
+
+install_binary() {
+  local name="$1"
+  local src="$2"
+  local dst="$INSTALL_DIR/$name"
+  if [[ ! -f "$src" ]]; then
+    return 0
+  fi
+  mkdir -p "$INSTALL_DIR"
+  cp "$src" "$dst"
+  chmod +x "$dst"
+  echo "Installed $dst"
+}
+
+path_hint() {
+  case ":$PATH:" in
+    *":$INSTALL_DIR:"*) return 0 ;;
+  esac
+  echo
+  echo "Add to PATH (e.g. in ~/.bashrc or ~/.zshrc):"
+  echo "  export PATH=\"$INSTALL_DIR:\$PATH\""
+}
+
+ROOT="$(resolve_source)"
+RELEASE_DIR="$ROOT/target/release"
+
+ensure_cargo
+
+if [[ ! -f "$RELEASE_DIR/apollo" ]]; then
+  echo "Building apollo (release)..."
+  (cd "$ROOT" && cargo build --release)
+fi
+
+install_binary apollo "$RELEASE_DIR/apollo"
+install_binary apollo-install "$RELEASE_DIR/apollo-install"
+
+path_hint

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -16,7 +16,7 @@ cleanup() {
 find_repo_root() {
   local dir="$1"
   while [[ -n "$dir" && "$dir" != "/" ]]; do
-    if [[ -f "$dir/Cargo.toml" ]] && grep -q '^name = "apollo"' "$dir/Cargo.toml" 2>/dev/null; then
+    if [[ -f "$dir/Cargo.toml" ]] && grep -qE '^name = "apollo(-agent)?"' "$dir/Cargo.toml" 2>/dev/null; then
       printf '%s\n' "$dir"
       return 0
     fi

--- a/src/autonomous.rs
+++ b/src/autonomous.rs
@@ -121,6 +121,19 @@ impl AutonomousLoop {
         }
     }
 
+    pub fn start_fresh(&mut self) {
+        self.status = AutonomousStatus::new();
+        Self::save_status_to_file(&self.status, &self.status_path);
+    }
+
+    pub fn resume(&mut self) {
+        self.status.paused = false;
+        if self.status.state == AutonomousState::Paused {
+            self.status.state = AutonomousState::Idle;
+        }
+        Self::save_status_to_file(&self.status, &self.status_path);
+    }
+
     /// Start the autonomous loop. Runs indefinitely.
     pub async fn run(self, agent: std::sync::Arc<crate::agent::AgentRunner>) {
         let config = self.config.clone();

--- a/src/bin/apollo_install.rs
+++ b/src/bin/apollo_install.rs
@@ -47,6 +47,18 @@ fn copy_exe(src: &Path, dst: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
+fn path_hint(dest: &Path) {
+    let in_path = std::env::var_os("PATH")
+        .map(|paths| std::env::split_paths(&paths).any(|p| p == dest))
+        .unwrap_or(false);
+    if in_path {
+        return;
+    }
+    eprintln!();
+    eprintln!("Add to PATH (e.g. in ~/.bashrc or ~/.zshrc):");
+    eprintln!("  export PATH=\"{}:$PATH\"", dest.display());
+}
+
 fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     match cli.cmd {
@@ -65,6 +77,15 @@ fn main() -> anyhow::Result<()> {
             let dst = dest.join("apollo");
             copy_exe(&src, &dst)?;
             println!("Installed {}", dst.display());
+            if let Some(parent) = src.parent() {
+                let installer = parent.join("apollo-install");
+                if installer.is_file() {
+                    let idst = dest.join("apollo-install");
+                    copy_exe(&installer, &idst)?;
+                    println!("Installed {}", idst.display());
+                }
+            }
+            path_hint(&dest);
         }
         Cmd::Uninstall { dest } => {
             let dest = expand_dest(&dest);

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -29,6 +29,13 @@ pub fn load_config(path: &str) -> Config {
     load_config_workspace(path, None)
 }
 
+pub fn require_config_file(path: &str) -> anyhow::Result<()> {
+    if !Path::new(path).exists() {
+        anyhow::bail!("Config not found at {path}. Run `apollo init` to create one.");
+    }
+    Ok(())
+}
+
 pub fn load_config_workspace(path: &str, workspace: Option<&Path>) -> Config {
     let mut cfg = Config::load(path).unwrap_or_else(|_| {
         tracing::warn!("Config not found at {}, using defaults", path);
@@ -400,4 +407,25 @@ fn resolve_openclaw_token(provider: &str) -> anyhow::Result<String> {
         "No {} credentials in auth-profiles",
         provider
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn require_config_file_errors_when_missing() {
+        let path = "/tmp/apollo-bootstrap-missing-config-test-xyz123.json";
+        let err = require_config_file(path).unwrap_err();
+        assert!(err.to_string().contains("Config not found"));
+        assert!(err.to_string().contains(path));
+    }
+
+    #[test]
+    fn require_config_file_ok_when_present() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("apollo.json");
+        std::fs::write(&path, "{}").unwrap();
+        require_config_file(path.to_str().unwrap()).unwrap();
+    }
 }

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -54,6 +54,8 @@ pub struct Check {
     pub name: String,
     pub ok: bool,
     pub detail: String,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub soft_warn: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -254,9 +256,20 @@ pub fn audit_config(cfg: &Config) -> Vec<Finding> {
     findings
 }
 
-pub async fn collect_doctor_report(cfg: Option<&Config>, verbose: bool) -> DoctorReport {
+pub async fn collect_doctor_report(
+    cfg: Option<&Config>,
+    config_path: Option<&str>,
+    verbose: bool,
+) -> DoctorReport {
     let mut checks = Vec::new();
-    let cfg = cfg.cloned().unwrap_or_else(Config::default_config);
+    if let Some(path) = config_path {
+        checks.push(check_config_file(path));
+    }
+    let cfg = cfg.cloned().unwrap_or_else(|| {
+        config_path
+            .and_then(|path| Config::load(path).ok())
+            .unwrap_or_else(Config::default_config)
+    });
 
     for (bin, label) in [
         ("git", "Git"),
@@ -275,15 +288,34 @@ pub async fn collect_doctor_report(cfg: Option<&Config>, verbose: bool) -> Docto
                 } else {
                     format!("{bin} is not on PATH")
                 },
+                soft_warn: false,
             });
         }
     }
 
+    let workspace_exists = cfg.workspace.exists();
     checks.push(Check {
         name: "Workspace".into(),
-        ok: cfg.workspace.exists(),
+        ok: workspace_exists,
         detail: cfg.workspace.display().to_string(),
+        soft_warn: false,
     });
+
+    let workspace_writable = workspace_exists && is_workspace_writable(&cfg.workspace);
+    checks.push(Check {
+        name: "Workspace writable".into(),
+        ok: workspace_writable,
+        detail: if !workspace_exists {
+            "workspace does not exist".into()
+        } else if workspace_writable {
+            "workspace is writable".into()
+        } else {
+            "workspace is not writable".into()
+        },
+        soft_warn: false,
+    });
+
+    checks.push(local_bin_path_check());
 
     let provider_key_present = cfg.provider.api_key.is_some()
         || std::env::var("ANTHROPIC_API_KEY").is_ok()
@@ -296,24 +328,28 @@ pub async fn collect_doctor_report(cfg: Option<&Config>, verbose: bool) -> Docto
         } else {
             "No provider credentials detected".into()
         },
+        soft_warn: false,
     });
 
     checks.push(Check {
         name: "Gateway bind".into(),
         ok: is_loopback_bind(cfg.gateway.bind.trim()),
         detail: cfg.gateway.bind.clone(),
+        soft_warn: false,
     });
 
     checks.push(Check {
         name: "Gateway rate limit".into(),
         ok: cfg.gateway.rate_limit_per_minute > 0,
         detail: format!("{} req/min", cfg.gateway.rate_limit_per_minute),
+        soft_warn: false,
     });
 
     checks.push(Check {
         name: "Gateway timeout".into(),
         ok: cfg.gateway.request_timeout_secs > 0,
         detail: format!("{}s", cfg.gateway.request_timeout_secs),
+        soft_warn: false,
     });
 
     DoctorReport {
@@ -357,13 +393,83 @@ pub fn render_doctor_report(report: &DoctorReport) -> String {
         "Checks:".to_string(),
     ];
     for check in &report.checks {
-        let icon = if check.ok { "OK" } else { "FAIL" };
+        let icon = if check.ok {
+            "OK"
+        } else if check.soft_warn {
+            "WARN"
+        } else {
+            "FAIL"
+        };
         out.push(format!("- [{icon}] {}: {}", check.name, check.detail));
     }
     out.push(String::new());
     out.push("Audit:".to_string());
     out.push(render_findings(&report.findings));
     out.join("\n")
+}
+
+pub(crate) fn check_config_file(path: &str) -> Check {
+    let file = Path::new(path);
+    if !file.exists() {
+        return Check {
+            name: "Config file".into(),
+            ok: false,
+            detail: format!("{path} not found"),
+            soft_warn: false,
+        };
+    }
+    match Config::load(path) {
+        Ok(_) => Check {
+            name: "Config file".into(),
+            ok: true,
+            detail: format!("{path} parses OK"),
+            soft_warn: false,
+        },
+        Err(err) => Check {
+            name: "Config file".into(),
+            ok: false,
+            detail: format!("{path} invalid: {err}"),
+            soft_warn: false,
+        },
+    }
+}
+
+fn is_workspace_writable(path: &Path) -> bool {
+    let probe = path.join(format!(".apollo-write-test-{}", std::process::id()));
+    match std::fs::File::create(&probe) {
+        Ok(_) => {
+            let _ = std::fs::remove_file(probe);
+            true
+        }
+        Err(_) => false,
+    }
+}
+
+fn local_bin_path_check() -> Check {
+    let on_path = local_bin_on_path();
+    Check {
+        name: "~/.local/bin on PATH".into(),
+        ok: on_path,
+        detail: if on_path {
+            "~/.local/bin is on PATH".into()
+        } else {
+            "~/.local/bin is not on PATH (optional)".into()
+        },
+        soft_warn: true,
+    }
+}
+
+fn local_bin_on_path() -> bool {
+    let Ok(home) = std::env::var("HOME") else {
+        return false;
+    };
+    let local_bin = Path::new(&home).join(".local/bin");
+    let Ok(path_env) = std::env::var("PATH") else {
+        return false;
+    };
+    path_env
+        .split(':')
+        .any(|entry| Path::new(entry) == local_bin.as_path())
 }
 
 fn is_loopback_bind(bind: &str) -> bool {
@@ -486,5 +592,57 @@ mod tests {
         assert!(findings
             .iter()
             .any(|f| f.code == "gateway_origins_unrestricted" && f.severity == Severity::Warn));
+    }
+
+    #[test]
+    fn render_doctor_report_marks_soft_warn_and_fail() {
+        let report = DoctorReport {
+            findings: vec![],
+            checks: vec![
+                Check {
+                    name: "passing".into(),
+                    ok: true,
+                    detail: "all good".into(),
+                    soft_warn: false,
+                },
+                Check {
+                    name: "optional missing".into(),
+                    ok: false,
+                    detail: "not on PATH (optional)".into(),
+                    soft_warn: true,
+                },
+                Check {
+                    name: "required missing".into(),
+                    ok: false,
+                    detail: "not found".into(),
+                    soft_warn: false,
+                },
+            ],
+        };
+        let rendered = render_doctor_report(&report);
+        assert!(rendered.contains("- [OK] passing: all good"));
+        assert!(rendered.contains("- [WARN] optional missing: not on PATH (optional)"));
+        assert!(rendered.contains("- [FAIL] required missing: not found"));
+    }
+
+    #[test]
+    fn check_config_file_reports_missing_path() {
+        let path = "/tmp/apollo-doctor-missing-config-test-xyz123.json";
+        let check = check_config_file(path);
+        assert!(!check.ok);
+        assert!(!check.soft_warn);
+        assert_eq!(check.name, "Config file");
+        assert!(check.detail.contains("not found"));
+    }
+
+    #[test]
+    fn check_config_file_reports_valid_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("apollo.json");
+        std::fs::write(&path, "{}").unwrap();
+        let check = check_config_file(path.to_str().unwrap());
+        assert!(check.ok);
+        assert!(!check.soft_warn);
+        assert!(check.detail.contains("parses OK"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,8 +8,10 @@ use clap::{Parser, Subcommand};
 
 use apollo::agent::hooks::PermissionHook;
 use apollo::agent::{agent_mode_from_permission_profile, AgentRunner};
+use apollo::autonomous::{AutonomousConfig, AutonomousLoop};
 use apollo::bootstrap::{
     build_base_tools, build_embedding_provider, build_memory_backend, build_provider, load_config,
+    require_config_file,
 };
 #[cfg(feature = "channel-cli")]
 use apollo::channels::cli::CliChannel;
@@ -26,10 +28,10 @@ use apollo::skills;
 use apollo::telegram_runtime::{run_telegram_chat, TelegramChatRun};
 
 #[derive(Parser)]
-#[command(name = "apollo", about = "Lightweight agent runtime — Apollo", version)]
+#[command(name = "apollo", about = "Local-first AI agent runtime", version)]
 struct Cli {
     #[command(subcommand)]
-    command: Commands,
+    command: Option<Commands>,
 }
 
 #[derive(Subcommand)]
@@ -143,6 +145,7 @@ enum Commands {
     },
 
     /// Initialize configuration (interactive wizard or one-command setup)
+    #[command(alias = "setup")]
     Init {
         /// Provider (omit to pick from compiled-in list with type-to-filter)
         #[arg(short, long)]
@@ -216,6 +219,29 @@ enum Commands {
         /// Workspace directory
         #[arg(short, long)]
         workspace: Option<PathBuf>,
+    },
+
+    /// Run autonomous TODO.md-driven coding loop
+    Autonomous {
+        /// Configuration file path
+        #[arg(short, long, default_value = "apollo.json")]
+        config: String,
+
+        /// Workspace directory
+        #[arg(short, long)]
+        workspace: Option<PathBuf>,
+
+        /// Check cycle interval in seconds
+        #[arg(long)]
+        interval: Option<u64>,
+
+        /// Reset autonomous status and start fresh
+        #[arg(long, default_value_t = false)]
+        start: bool,
+
+        /// Clear paused state and continue
+        #[arg(long, default_value_t = false)]
+        resume: bool,
     },
 
     /// Swarm commands (multi-agent coordination)
@@ -409,7 +435,19 @@ async fn main() -> anyhow::Result<()> {
         .unwrap_or_default();
     init_tracing(&tracing_cfg)?;
 
-    match cli.command {
+    // Hermes-style: bare `apollo` starts interactive chat.
+    let command = cli.command.unwrap_or(Commands::Chat {
+        config: "apollo.json".into(),
+        model: None,
+        workspace: None,
+        channel: "cli".into(),
+        telegram_token: None,
+        telegram_chat_id: None,
+        discord_token: None,
+        discord_channel_id: None,
+    });
+
+    match command {
         Commands::Chat {
             config,
             model,
@@ -420,6 +458,7 @@ async fn main() -> anyhow::Result<()> {
             discord_token: _discord_token,
             discord_channel_id: _discord_channel_id,
         } => {
+            require_config_file(&config)?;
             let workspace = workspace.unwrap_or_else(|| load_config(&config).workspace.clone());
             let cfg = apollo::bootstrap::load_config_workspace(&config, Some(&workspace));
             let model = model.unwrap_or(cfg.model.clone());
@@ -678,6 +717,7 @@ async fn main() -> anyhow::Result<()> {
             config,
             model,
         } => {
+            require_config_file(&config)?;
             let cfg = load_config(&config);
             let model = model.unwrap_or(cfg.model.clone());
             let provider = build_provider(&cfg);
@@ -692,7 +732,7 @@ async fn main() -> anyhow::Result<()> {
             json,
         } => {
             let cfg = load_config(&config);
-            let report = collect_doctor_report(Some(&cfg), verbose).await;
+            let report = collect_doctor_report(Some(&cfg), Some(&config), verbose).await;
             if json {
                 println!("{}", serde_json::to_string_pretty(&report)?);
             } else {
@@ -714,7 +754,7 @@ async fn main() -> anyhow::Result<()> {
             println!("apollo v{}", env!("CARGO_PKG_VERSION"));
             println!("Status: OK");
             println!(
-                "Commands: chat, ask, doctor, audit, status, mcp, self-update, init, cron, swarm"
+                "Commands: chat, ask, doctor, audit, status, mcp, self-update, init, cron, autonomous, swarm"
             );
         }
 
@@ -1238,6 +1278,106 @@ async fn main() -> anyhow::Result<()> {
             }
         }
 
+        Commands::Autonomous {
+            config,
+            workspace,
+            interval,
+            start,
+            resume,
+        } => {
+            let workspace = workspace.unwrap_or_else(|| load_config(&config).workspace.clone());
+            let cfg = apollo::bootstrap::load_config_workspace(&config, Some(&workspace));
+            let model = cfg.model.clone();
+            let _ = apollo::workspace_init::ensure_workspace_kit(&workspace);
+
+            let provider = build_provider(&cfg);
+            let policy = Arc::new(ExecutionPolicy::from_config(&cfg.policy));
+            let memory = build_memory_backend(&workspace, &cfg).await?;
+            let embedding_provider = build_embedding_provider(&cfg)?;
+
+            let system_prompt = prompt::build_system_prompt(&workspace).await;
+            let discovered_skills = skills::discover_skills_for_workspace(Some(&workspace));
+
+            #[cfg(feature = "zkr-memory")]
+            let zkr_store = apollo::bootstrap::build_zkr_store(&workspace, &cfg)
+                .ok()
+                .flatten();
+            #[cfg(feature = "zkr-memory")]
+            let mut tools = build_base_tools(
+                &workspace,
+                Arc::clone(&policy),
+                memory.clone(),
+                embedding_provider,
+                Arc::clone(&provider),
+                &cfg,
+                zkr_store.clone(),
+            );
+            #[cfg(not(feature = "zkr-memory"))]
+            let mut tools = build_base_tools(
+                &workspace,
+                Arc::clone(&policy),
+                memory.clone(),
+                embedding_provider,
+                Arc::clone(&provider),
+                &cfg,
+            );
+
+            for dt in apollo::tools::dynamic::DynamicTool::load_all(Arc::clone(&policy)) {
+                tools.push(Arc::new(dt));
+            }
+
+            let mut runner =
+                AgentRunner::new(provider, tools, memory.clone(), &system_prompt, model)
+                    .with_config(cfg.agent.clone())
+                    .with_mode(agent_mode_from_permission_profile(
+                        &cfg.agent.permission_profile,
+                    ))
+                    .with_workspace(workspace.clone())
+                    .with_memory_ideas(cfg.memory.clone())
+                    .with_group_chat(cfg.group_chat.clone())
+                    .with_skills(discovered_skills)
+                    .await;
+            #[cfg(feature = "zkr-memory")]
+            {
+                runner = runner.with_zkr(zkr_store.clone(), cfg.zkr.clone());
+            }
+
+            {
+                let mut host_reg = apollo::plugin::PluginRegistry::new();
+                host_reg.ingest_host_plugins(&workspace, &cfg.plugin_layer.host_plugin_roots);
+                runner = runner.with_plugin_registry(host_reg).await;
+            }
+
+            let runner_arc = Arc::new(runner);
+            runner_arc.add_hook(Arc::new(PermissionHook::new(
+                cfg.agent.permissions.deny.clone(),
+                cfg.agent.permissions.allow.clone(),
+            )));
+
+            let mut autonomous_config = AutonomousConfig::default();
+            if let Some(secs) = interval {
+                autonomous_config.interval_secs = secs;
+            }
+            let interval_secs = autonomous_config.interval_secs;
+
+            let mut autonomous_loop = AutonomousLoop::new(autonomous_config, workspace.clone());
+            if start {
+                autonomous_loop.start_fresh();
+            } else if resume {
+                autonomous_loop.resume();
+            }
+
+            println!(
+                "apollo v{} — autonomous mode (interval={}s)",
+                env!("CARGO_PKG_VERSION"),
+                interval_secs
+            );
+            println!("   Workspace: {}", workspace.display());
+            println!("   Press Ctrl+C to stop");
+
+            autonomous_loop.run(runner_arc).await;
+        }
+
         Commands::Swarm { action, workspace } => {
             #[cfg(not(feature = "swarm"))]
             {
@@ -1634,13 +1774,15 @@ fn prompt_permission_profile_interactive() -> anyhow::Result<String> {
 
 fn config_path_for_cli(cli: &Cli) -> Option<String> {
     match &cli.command {
-        Commands::Chat { config, .. }
-        | Commands::Ask { config, .. }
-        | Commands::Doctor { config, .. }
-        | Commands::Audit { config, .. }
-        | Commands::SelfUpdate { config, .. }
-        | Commands::Mcp { config, .. } => Some(config.clone()),
-        _ => None,
+        None => Some("apollo.json".into()),
+        Some(Commands::Chat { config, .. })
+        | Some(Commands::Ask { config, .. })
+        | Some(Commands::Doctor { config, .. })
+        | Some(Commands::Audit { config, .. })
+        | Some(Commands::SelfUpdate { config, .. })
+        | Some(Commands::Mcp { config, .. })
+        | Some(Commands::Autonomous { config, .. }) => Some(config.clone()),
+        Some(_) => None,
     }
 }
 

--- a/src/tools/doctor.rs
+++ b/src/tools/doctor.rs
@@ -52,7 +52,7 @@ impl Tool for DoctorTool {
     async fn execute(&self, arguments: &str) -> anyhow::Result<ToolResult> {
         let args: DoctorArgs =
             serde_json::from_str(arguments).unwrap_or(DoctorArgs { verbose: false });
-        let report = collect_doctor_report(None, args.verbose).await;
+        let report = collect_doctor_report(None, Some("apollo.json"), args.verbose).await;
         Ok(ToolResult::success(render_doctor_report(&report)))
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Switch license to **MPL-2.0** (`LICENSE` + `Cargo.toml`)
- Add Cursor Cloud Agent environment (`.cursor/Dockerfile`, `environment.json`, `scripts/cloud-agent-install.sh`)
- Hermes-style CLI QoL:
  - bare `apollo` starts interactive chat
  - `apollo setup` aliases `apollo init`
  - `apollo autonomous` wired for TODO.md loop
  - clearer doctor/install PATH hints + config-file checks
  - `scripts/install.sh` one-liner-friendly installer

## Validation

- `cargo fmt --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test` ✅ (147 passed)

## Blocker for crates.io

Package name `apollo` is **reserved** on crates.io by Apollo GraphQL. Publish needs a rename (e.g. `apollo-agent`, `apollo-cli`, `apollo-runtime`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01004882-d1a6-4802-bc8d-9d14c5714b45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01004882-d1a6-4802-bc8d-9d14c5714b45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

