### PR TITLE
chore(deps): update rx4 to 0.6.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6856,9 +6856,9 @@ dependencies = [
 
 [[package]]
 name = "rx4"
-version = "0.5.0"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2caf829fd2dfb658bc4395aaf057494d604d97f4f37e518042eb8ed64a26a26"
+checksum = "be35dbc87bca2acc8176f6bf938dfe0721acde1581ae96029584be371e7c1129"
 dependencies = [
  "async-trait",
  "cancellation-token",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ computer-use-praefectus = ["dep:praefectus", "dep:ed25519-dalek"]
 # Deliberately off: `builtin-tools` (apollo registers its own tools; also
 # pulls in the fff/git2/notify stack), `mcp` (apollo has src/mcp_server.rs),
 # `zkr-memory` (gates rx4's self_improve; apollo depends on zkr directly).
-rx4 = { version = "0.5.0", default-features = false, features = ["ipc", "providers", "skills", "graph-memory"] }
+rx4 = { version = "0.6.3", default-features = false, features = ["ipc", "providers", "skills", "graph-memory"] }
 
 # Async runtime (optimized features only)
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util", "sync", "time", "fs", "signal", "process", "io-std"] }

--- a/src/agent/rotary_bridge.rs
+++ b/src/agent/rotary_bridge.rs
@@ -420,6 +420,7 @@ pub fn register_apollo_tools(
                     id: String::new(),
                     content: result.output,
                     is_error: result.is_error,
+                    error_kind: None,
                 }
             })
         });


### PR DESCRIPTION
Updates rx4 from 0.5.0 to the published 0.6.3 release, retaining the existing selected feature set.

Validation: dependency resolution succeeded; full `cargo check` is running in the release-update workspace.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> rx4 owns the core agent loop via RotaryAgentBridge, so a minor version bump can introduce API or behavior changes even without local code edits.
> 
> **Overview**
> Bumps the **rx4** agent harness dependency from `0.5.0` to `0.6.3`, keeping the same feature set (`ipc`, `providers`, `skills`, `graph-memory`).
> 
> No application code changes — only `Cargo.toml` and `Cargo.lock`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d35cf2123f126064782aa72f30b27e22ce7d491. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->